### PR TITLE
chore: update Hugo modules (2026-04-17)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/hugolify/hugolify-theme-projects v1.2.4 // indirect
 	github.com/hugolify/hugolify-theme-projects-tags v1.1.3 // indirect
 	github.com/hugolify/hugolify-theme-projects-types v1.0.15 // indirect
-	github.com/midzer/tobii v3.1.3+incompatible // indirect
+	github.com/midzer/tobii v3.2.0+incompatible // indirect
 	github.com/orestbida/cookieconsent v3.1.0+incompatible // indirect
 	github.com/twbs/bootstrap v5.3.8+incompatible // indirect
 	github.com/twbs/icons v1.13.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/hugolify/hugolify-theme-projects-tags v1.1.3 h1:R0hRoxvupoPRuBJjHxhVS
 github.com/hugolify/hugolify-theme-projects-tags v1.1.3/go.mod h1:/4CdPgLuI/lKr5v3312vCuhjQyJUnfptGxvIgZhwe3Q=
 github.com/hugolify/hugolify-theme-projects-types v1.0.15 h1:VsdL2pqcz64Bc4vIeW6ZnGbXSxHddvhmJw52yHTESD8=
 github.com/hugolify/hugolify-theme-projects-types v1.0.15/go.mod h1:6w9aM4KMjvQspp6wm67iFZzVRuC6gRR3PTXgxud8BAg=
-github.com/midzer/tobii v3.1.3+incompatible h1:3h2eGycwcHuTWeBLg5bqCLx3EcPSV1rHT1btiu4A3k0=
-github.com/midzer/tobii v3.1.3+incompatible/go.mod h1:ByXFkVm8ja2+TXT7L+lfkdEIeHW4IdWdsQO8zJ5mEqA=
+github.com/midzer/tobii v3.2.0+incompatible h1:+08xCdrQ8dlXrkBIOJFsIUsfgme4Ou1CUfbqDmeX/Hc=
+github.com/midzer/tobii v3.2.0+incompatible/go.mod h1:ByXFkVm8ja2+TXT7L+lfkdEIeHW4IdWdsQO8zJ5mEqA=
 github.com/orestbida/cookieconsent v3.1.0+incompatible h1:L2uj16SEL1bICkn6pJde9uc1qAPmTcEiFZO93zZKdQI=
 github.com/orestbida/cookieconsent v3.1.0+incompatible/go.mod h1:8N46VI/40AwvzASJDpiwfbu6zylSzKSDZRUVNmVXLxw=
 github.com/twbs/bootstrap v5.3.8+incompatible h1:eK1fsXP7R/FWFt+sSNmmvUH9usPocf240nWVw7Dh02o=


### PR DESCRIPTION

## Date
vendredi 17 avril 2026

## Status
✅ Success

## Updated modules
### go.mod

```diff
@@ -14 +14 @@ require (
-	github.com/midzer/tobii v3.1.3+incompatible // indirect
+	github.com/midzer/tobii v3.2.0+incompatible // indirect
```

### go.sum

```diff
@@ -17,2 +17,2 @@ github.com/hugolify/hugolify-theme-projects-types v1.0.15/go.mod h1:6w9aM4KMjvQs
-github.com/midzer/tobii v3.1.3+incompatible h1:3h2eGycwcHuTWeBLg5bqCLx3EcPSV1rHT1btiu4A3k0=
-github.com/midzer/tobii v3.1.3+incompatible/go.mod h1:ByXFkVm8ja2+TXT7L+lfkdEIeHW4IdWdsQO8zJ5mEqA=
+github.com/midzer/tobii v3.2.0+incompatible h1:+08xCdrQ8dlXrkBIOJFsIUsfgme4Ou1CUfbqDmeX/Hc=
+github.com/midzer/tobii v3.2.0+incompatible/go.mod h1:ByXFkVm8ja2+TXT7L+lfkdEIeHW4IdWdsQO8zJ5mEqA=
```


